### PR TITLE
Update shm_timer.hpp

### DIFF
--- a/src/shm_timer.hpp
+++ b/src/shm_timer.hpp
@@ -37,6 +37,8 @@ namespace shm_timer
             printf("shm_timer mmap failed!!!\n");
             return;
         }
+        //关闭文件描述符
+        close(fd);
     }
 
     void close()


### PR DESCRIPTION
修复shm_timer::open()函数的bug，添加了关闭文件描述符的行为。解决了launch运行一段时间后因打开文件数量超过系统限制而中止的问题